### PR TITLE
Add ReStructuredText eval example

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,16 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.5.0] - 2022-12-17
+### Added
+- Example for ReStructuredText evaluation directive to show a warning and a notes highlighted text
+
+### Changed
+- Removed outdated command to convert Markdown files to ReStructuredText files
+
+### Fixed
+- Call to generate sphinx documentation in USAGE
+
 ## [0.4.0] - 2022-12-06
 ### Added
 - Usage guide for building docs locally in root README
@@ -60,8 +70,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
   files for Sphinx
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/rtd-tutorial-template/compare/0.4.0...main
+[Unreleased]: https://github.com/brainelectronics/rtd-tutorial-template/compare/0.5.0...main
 
+[0.5.0]: https://github.com/brainelectronics/rtd-tutorial-template/tree/0.5.0
 [0.4.0]: https://github.com/brainelectronics/rtd-tutorial-template/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/rtd-tutorial-template/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/rtd-tutorial-template/tree/0.2.0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -42,15 +42,6 @@ source .venv/bin/activate
 pip install -r docs/requirements.txt
 ```
 
-### Convert Markdown to ReStructuredText
-
-```bash
-python docs/convert_md2rst.py \
-	--destination docs/source/ \
-	--in_file docs/README.md \
-	--in_file other/nested/README.md
-```
-
 ### Sphinx link checks
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -20,6 +20,18 @@ function can be used. The list will contain 5 integers between 0 and 100 by
 default. The `how_long` argument can be used to change the number of elements
 in the returned list.
 
+```{note} Notes require **no** arguments, so content can start here.
+```
+
+```{eval-rst}
+.. warning::
+    This is warning text. Use a warning for information the user must
+    understand to avoid negative consequences.
+
+    Warnings are formatted in the same way as notes. In the same way,
+    lines must be broken and indented under the warning tag.
+```
+
 ## Create docs
 
 ### Installation

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -46,16 +46,16 @@ pip install -r docs/requirements.txt
 
 ```bash
 sphinx-build \
-	docs/source docs/build/html \
-	-d docs/build/docs_doctree \
-	--color -blinkcheck -bhtml -W
+    docs/ docs/build/linkcheck \
+    -d docs/build/docs_doctree \
+    --color -blinkcheck -W
 ```
 
 ### Sphinx build
 
 ```bash
 sphinx-build \
-	docs/source docs/build/linkcheck \
-	-d docs/build/docs_doctree \
-    --color -W
+    docs/ docs/build/html \
+    -d docs/build/docs_doctree \
+    --color -bhtml -W
 ```


### PR DESCRIPTION
### Added
- Example for ReStructuredText evaluation directive to show a warning and a notes highlighted text

### Changed
- Removed outdated command to convert Markdown files to ReStructuredText files

### Fixed
- Call to generate sphinx documentation in USAGE